### PR TITLE
Fix broken Icon Dialog - Update Github Repository Url

### DIFF
--- a/src/Sitecore.Rocks.VisualStudio/Shell/Commands/VisitWebsite.cs
+++ b/src/Sitecore.Rocks.VisualStudio/Shell/Commands/VisitWebsite.cs
@@ -19,7 +19,7 @@ namespace Sitecore.Rocks.Shell.Commands
 
         public override void Execute(object parameter)
         {
-            AppHost.Browsers.Navigate(@"https://github.com/JakobChristensen/Sitecore.Rocks");
+            AppHost.Browsers.Navigate(@"https://github.com/Sitecore/Sitecore.Rocks");
         }
     }
 }

--- a/src/Sitecore.Rocks.VisualStudio/source.extension.vsixmanifest
+++ b/src/Sitecore.Rocks.VisualStudio/source.extension.vsixmanifest
@@ -7,7 +7,7 @@
         <Description xml:space="preserve">Sitecore Rocks makes Sitecore developers happy.
 
 Directly integrated into Microsoft Visual Studio 2015/2017, Sitecore Rocks provides a fast and streamlined development experience with tools that developers are used to.        </Description>
-        <MoreInfo>https://github.com/JakobChristensen/Sitecore.Rocks</MoreInfo>
+        <MoreInfo>https://github.com/Sitecore/Sitecore.Rocks</MoreInfo>
         <License>Sitecore Rocks License Agreement (Final 092812).rtf</License>
         <Icon>Icon.png</Icon>
         <PreviewImage>Preview.png</PreviewImage>

--- a/src/Sitecore.Rocks/ContentEditors/Dialogs/SetIconDialog.xaml.cs
+++ b/src/Sitecore.Rocks/ContentEditors/Dialogs/SetIconDialog.xaml.cs
@@ -419,7 +419,7 @@ namespace Sitecore.Rocks.ContentEditors.Dialogs
             Debug.ArgumentNotNull(image, nameof(image));
             Debug.ArgumentNotNull(imageName, nameof(imageName));
 
-            var path = $"https://raw.githubusercontent.com/JakobChristensen/Sitecore.Rocks/master/icons/icons_{imageName}.png";
+            var path = $"https://raw.githubusercontent.com/Sitecore/Sitecore.Rocks/master/icons/icons_{imageName}.png";
 
             var policy = new RequestCachePolicy(RequestCacheLevel.Default);
 

--- a/src/Sitecore.Rocks/UI/QueryAnalyzers/QueryAnalyzer.xaml.cs
+++ b/src/Sitecore.Rocks/UI/QueryAnalyzers/QueryAnalyzer.xaml.cs
@@ -712,7 +712,7 @@ namespace Sitecore.Rocks.UI.QueryAnalyzers
             Debug.ArgumentNotNull(sender, nameof(sender));
             Debug.ArgumentNotNull(e, nameof(e));
 
-            AppHost.Browsers.Navigate("https://github.com/JakobChristensen/Sitecore.Rocks/blob/master/docs/QueryAnalyzer/QueryAnalyzerSamples.md");
+            AppHost.Browsers.Navigate("https://github.com/Sitecore/Sitecore.Rocks/blob/master/docs/QueryAnalyzer/QueryAnalyzerSamples.md");
         }
 
         private void OpenScript([NotNull] object sender, [NotNull] RoutedEventArgs e)

--- a/src/Sitecore.Rocks/UI/StartPage/Tabs/GetStarted/SitecoreRocks/LearnAboutSitecoreRocks/OpenVsPlugins.cs
+++ b/src/Sitecore.Rocks/UI/StartPage/Tabs/GetStarted/SitecoreRocks/LearnAboutSitecoreRocks/OpenVsPlugins.cs
@@ -10,7 +10,7 @@ namespace Sitecore.Rocks.UI.StartPage.Tabs.GetStarted.SitecoreRocks.LearnAboutSi
     {
         protected override void Execute()
         {
-            AppHost.Browsers.Navigate(@"https://github.com/JakobChristensen/Sitecore.Rocks");
+            AppHost.Browsers.Navigate(@"https://github.com/Sitecore/Sitecore.Rocks");
         }
     }
 }

--- a/src/Sitecore.Rocks/UI/StartPage/Tabs/GetStarted/SitecoreRocks/Plugins/VisualStudioProject.cs
+++ b/src/Sitecore.Rocks/UI/StartPage/Tabs/GetStarted/SitecoreRocks/Plugins/VisualStudioProject.cs
@@ -10,7 +10,7 @@ namespace Sitecore.Rocks.UI.StartPage.Tabs.GetStarted.SitecoreRocks.Plugins
     {
         protected override void Execute()
         {
-            AppHost.Browsers.Navigate(@"https://github.com/JakobChristensen/Sitecore.Rocks/blob/master/docs/Plugins/CreatingVisualStudioProjects.md");
+            AppHost.Browsers.Navigate(@"https://github.com/Sitecore/Sitecore.Rocks/blob/master/docs/Plugins/CreatingVisualStudioProjects.md");
         }
     }
 }


### PR DESCRIPTION
The Icon dialog currently fails to show icons. Rocks is getting a bunch of 404 errors when attempting to retrieve the icons. This appears to be down to the repo moving from https://github.com/JakobChristensen/Sitecore.Rocks to https://github.com/Sitecore/Sitecore.Rocks 

Have updated the URLs to match the new location.

Screenshot of problem:

![image](https://user-images.githubusercontent.com/16286329/54919127-e78a4d00-4ef7-11e9-9cdd-3f8c13d1f9f7.png)



