### PR TITLE
Update extension to also support VS2019

### DIFF
--- a/src/Sitecore.Rocks.VisualStudio/source.extension.vsixmanifest
+++ b/src/Sitecore.Rocks.VisualStudio/source.extension.vsixmanifest
@@ -14,9 +14,9 @@ Directly integrated into Microsoft Visual Studio 2015/2017, Sitecore Rocks provi
         <Tags>Sitecore, Sitecore Rocks, CMS, ASP.NET, C#</Tags>
     </Metadata>
     <Installation>
-        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,15.0]" />
-        <InstallationTarget Version="[14.0,15.0]" Id="Microsoft.VisualStudio.Pro" />
-        <InstallationTarget Version="[14.0,15.0]" Id="Microsoft.VisualStudio.Enterprise" />
+        <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[14.0,17.0)" />
+        <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Pro" />
+        <InstallationTarget Version="[14.0,17.0)" Id="Microsoft.VisualStudio.Enterprise" />
     </Installation>
     <Dependencies>
         <Dependency Id="Microsoft.Framework.NDP" DisplayName="Microsoft .NET Framework" d:Source="Manual" Version="[4.5,)" />
@@ -74,6 +74,6 @@ Directly integrated into Microsoft Visual Studio 2015/2017, Sitecore Rocks provi
         <Asset Type="Microsoft.VisualStudio.VsPackage" d:Source="File" Path="CommandLineSwitches.pkgdef" />
     </Assets>
     <Prerequisites>
-        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.26208.0,16.0)" DisplayName="Visual Studio core editor" />
+        <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[15.0.26208.0,)" DisplayName="Visual Studio core editor" />
     </Prerequisites>
 </PackageManifest>


### PR DESCRIPTION
Per Mads Kristensen (MSFT Sr PM of VS Extensibility), it's a manifest-only change... https://devblogs.microsoft.com/visualstudio/how-to-upgrade-extensions-to-support-visual-studio-2019/