### PR TITLE
[closes #107] ensure that sitecore_userticket is not sent as a cookie

### DIFF
--- a/src/Sitecore.Rocks/Data/DataServices/AspxAuthCookieClientMessageInspector.cs
+++ b/src/Sitecore.Rocks/Data/DataServices/AspxAuthCookieClientMessageInspector.cs
@@ -51,7 +51,7 @@ namespace Sitecore.Rocks.Data.DataServices
             foreach (var cookieName in _cookies)
             {
                 var cookieValue = GetCookie(cookieHeader, cookieName);
-                if (string.IsNullOrEmpty(cookieValue))
+                if (cookieValue == null)
                 {
                     continue;
                 }
@@ -86,7 +86,7 @@ namespace Sitecore.Rocks.Data.DataServices
                 return result;
             }
 
-            return string.Empty;
+            return null;
         }
 
         /// <summary>


### PR DESCRIPTION


* was causing web client users to log out due to behavior of Owin Auth and TicketManager