### PR TITLE
[closes #120] Resolve issue with Sitecore 8.x compatibility

### DIFF
--- a/src/Sitecore.Rocks.Server/Requests/Items/GetItemFields.cs
+++ b/src/Sitecore.Rocks.Server/Requests/Items/GetItemFields.cs
@@ -236,7 +236,7 @@ namespace Sitecore.Rocks.Server.Requests.Items
             }
             catch (Exception ex)
             {
-                Log.Error("Failed to get Lookup source", ex);
+                Log.Error("Failed to get Lookup source", ex, this);
                 items = null;
             }
 

--- a/tests/code/instance/App_Config/Include/zzz/RocksTestData.config
+++ b/tests/code/instance/App_Config/Include/zzz/RocksTestData.config
@@ -14,6 +14,7 @@
       </configurations>
       <authenticationProvider type="Unicorn.ControlPanel.Security.ChapAuthenticationProvider, Unicorn">
         <SharedSecret>nobody-sits-like-this-rock-sits--you-rock-rock</SharedSecret>
+        <WriteAuthFailuresToLog>true</WriteAuthFailuresToLog>
       </authenticationProvider>
     </unicorn>
     <settings>

--- a/tests/code/instance/UnicornConfig.csproj
+++ b/tests/code/instance/UnicornConfig.csproj
@@ -59,7 +59,7 @@
   </ItemGroup>
   <ItemGroup>
     <Content Include="App_Config\Include\Rainbow.config" />
-    <Content Include="App_Config\Include\RocksTestData.config" />
+    <Content Include="App_Config\Include\zzz\RocksTestData.config" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Properties\PublishProfiles\FilesystemPublish.pubxml" />

--- a/tests/code/tests/ClientFactory.cs
+++ b/tests/code/tests/ClientFactory.cs
@@ -21,14 +21,29 @@ namespace Sitecore.Rocks.Server.IntegrationTests
             }
         }
 
+        public static Version SitecoreVersion
+        {
+            get
+            {
+                var version = System.Environment.GetEnvironmentVariable("SitecoreVersion") ??
+                           "9.1";
+                return new Version(version);
+            }
+        }
+
         public static SitecoreWebService2SoapClient Client
         {
             get
             {
                 var client = new SitecoreWebService2SoapClient();
                 client.Endpoint.Address = new EndpointAddress(EndPoint);
+                var binding = (BasicHttpBinding)client.Endpoint.Binding;
+                if (!EndPoint.StartsWith("https"))
+                {
+                    binding.Security.Mode = BasicHttpSecurityMode.None;
+                }
                 // Need to up buffer size due to size of some results, e.g. GetsLayout on core
-                ((BasicHttpBinding) client.Endpoint.Binding).MaxReceivedMessageSize = 1024 * 1024 * 16;
+                binding.MaxReceivedMessageSize = 1024 * 1024 * 16;
                 return client;
             }
         }

--- a/tests/scripts/sc826/test.ps1
+++ b/tests/scripts/sc826/test.ps1
@@ -1,0 +1,4 @@
+$ErrorActionPreference = "Stop"
+Import-Module ..\Invoke-Test.psm1
+
+Invoke-Test -RocksLocation "C:\Sitecore\sc826\Website" -RocksHost "http://sc826.local" -SitecoreVersion "8.2" -DataFolder "..\data"

--- a/tests/scripts/sc911/test.ps1
+++ b/tests/scripts/sc911/test.ps1
@@ -1,4 +1,4 @@
 $ErrorActionPreference = "Stop"
 Import-Module ..\Invoke-Test.psm1
 
-Invoke-Test -RocksLocation "c:\Inetpub\wwwroot\rocksTest911.local" -RocksHost "https://rocksTest911.local"
+Invoke-Test -RocksLocation "c:\Inetpub\wwwroot\rocksTest911.local" -RocksHost "https://rocksTest911.local" -SitecoreVersion "9.1"

--- a/tests/scripts/sc920/test.ps1
+++ b/tests/scripts/sc920/test.ps1
@@ -1,4 +1,4 @@
 $ErrorActionPreference = "Stop"
 Import-Module ..\Invoke-Test.psm1
 
-Invoke-Test -RocksLocation "c:\Inetpub\wwwroot\rocksTest920.local" -RocksHost "https://rocksTest920.local"
+Invoke-Test -RocksLocation "c:\Inetpub\wwwroot\rocksTest920.local" -RocksHost "https://rocksTest920.local" -SitecoreVersion "9.2"


### PR DESCRIPTION
* Signature change in Sitecore.Diagnostics.Log and bad logging statement in GetItemFields request caused a MissingMethodException on 8.x.
* Added integration test script for 8.2 and updated tests as needed to pass against 8.2.